### PR TITLE
Fix display widget being null

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -16,7 +16,7 @@
 */
 
 public class Sound.Indicator : Wingpanel.Indicator {
-    private DisplayWidget? display_widget;
+    private DisplayWidget display_widget;
     private Gtk.Grid main_grid;
     private Widgets.Scale volume_scale;
     private Widgets.Scale mic_scale;


### PR DESCRIPTION
Before the `display_widget` was initialized, `volume_control` was already notifying about it's changes to various properties due to assigning them first time which fired methods that wanted to update the icon of the widget but failed. The `display_widget` is now initialized in `construct` and returned immediately in `get_display_widget` method. I'm also connecting the `button_press_event` and setting up of display widget after creation of `volume_control` because this lambda and other calls could actually access it.