### PR TITLE
Click icon to mute and cleanup

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -110,17 +110,17 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
     private void on_volume_change () {
         var volume = volume_control.volume.volume / this.max_volume;
-        volume_scale.get_scale ().set_value (volume);
+        volume_scale.scale_widget.set_value (volume);
         display_widget.icon_name = get_volume_icon (volume);
     }
 
     private void on_mic_volume_change () {
         var volume = volume_control.mic_volume;
-        mic_scale.get_scale ().set_value (volume);
+        mic_scale.scale_widget.set_value (volume);
     }
 
     private void on_mute_change () {
-        volume_scale.get_switch ().active = !volume_control.mute;
+        volume_scale.active = !volume_control.mute;
 
         string volume_icon = get_volume_icon (volume_control.volume.volume);
         display_widget.icon_name = volume_icon;
@@ -133,7 +133,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void on_mic_mute_change () {
-        mic_scale.get_switch ().active = !volume_control.micMute;
+        mic_scale.active = !volume_control.micMute;
     }
 
     private void on_is_playing_change () {
@@ -223,7 +223,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void on_volume_switch_change () {
-        if (volume_scale.get_switch ().active) {
+        if (volume_scale.active) {
             volume_control.set_mute (false);
         } else {
             volume_control.set_mute (true);
@@ -231,7 +231,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void on_mic_switch_change () {
-        if (mic_scale.get_switch ().active) {
+        if (mic_scale.active) {
             volume_control.set_mic_mute (false);
         } else {
             volume_control.set_mic_mute (true);
@@ -266,24 +266,24 @@ public class Sound.Indicator : Wingpanel.Indicator {
             }
 
             volume_scale.margin_start = 6;
-            volume_scale.get_switch ().active = !volume_control.mute;
-            volume_scale.get_switch ().notify["active"].connect (on_volume_switch_change);
+            volume_scale.active = !volume_control.mute;
+            volume_scale.notify["active"].connect (on_volume_switch_change);
 
-            volume_scale.get_scale ().value_changed.connect (() => {
+            volume_scale.scale_widget.value_changed.connect (() => {
                 var vol = new Services.VolumeControl.Volume();
-                var v = volume_scale.get_scale ().get_value () * this.max_volume;
+                var v = volume_scale.scale_widget.get_value () * this.max_volume;
                 vol.volume = v.clamp (0.0, this.max_volume);
                 vol.reason = Services.VolumeControl.VolumeReasons.USER_KEYPRESS;
                 this.volume_control.volume = vol;
-                volume_scale.set_icon (get_volume_icon (volume_scale.get_scale ().get_value ()));
+                volume_scale.set_icon (get_volume_icon (volume_scale.scale_widget.get_value ()));
             });
 
-            volume_scale.get_scale ().set_value (volume_control.volume.volume);
-            volume_scale.get_scale ().button_release_event.connect ((e) => {
+            volume_scale.scale_widget.set_value (volume_control.volume.volume);
+            volume_scale.scale_widget.button_release_event.connect ((e) => {
                 play_sound_blubble ();
                 return false;
             });
-            volume_scale.get_scale ().scroll_event.connect ((e) => {
+            volume_scale.scale_widget.scroll_event.connect ((e) => {
                 int dir = 0;
                 if (e.direction == Gdk.ScrollDirection.UP || e.direction == Gdk.ScrollDirection.RIGHT ||
                     (e.direction == Gdk.ScrollDirection.SMOOTH && e.delta_y < 0)) {
@@ -293,17 +293,17 @@ public class Sound.Indicator : Wingpanel.Indicator {
                     dir = -1;
                 }
 
-                double v = volume_scale.get_scale ().get_value ();
+                double v = volume_scale.scale_widget.get_value ();
                 v = v + volume_step_percentage * dir;
 
                 if (v >= -0.05 && v <= 1.05) {
-                    volume_scale.get_scale ().set_value (v);
+                    volume_scale.scale_widget.set_value (v);
                     play_sound_blubble ();
                 }
                 return true;
             });
 
-            volume_scale.set_icon (get_volume_icon (volume_scale.get_scale ().get_value ()));
+            volume_scale.set_icon (get_volume_icon (volume_scale.scale_widget.get_value ()));
             set_max_volume ();
 
             main_grid.attach (volume_scale, 0, position++, 1, 1);
@@ -311,11 +311,11 @@ public class Sound.Indicator : Wingpanel.Indicator {
             main_grid.attach (new Wingpanel.Widgets.Separator (), 0, position++, 1, 1);
 
             mic_scale.margin_start = 6;
-            mic_scale.get_switch ().active = !volume_control.micMute;
-            mic_scale.get_switch ().notify["active"].connect (on_mic_switch_change);
+            mic_scale.active = !volume_control.micMute;
+            mic_scale.notify["active"].connect (on_mic_switch_change);
 
-            mic_scale.get_scale ().value_changed.connect (() => {
-                volume_control.mic_volume = mic_scale.get_scale ().get_value ();
+            mic_scale.scale_widget.value_changed.connect (() => {
+                volume_control.mic_volume = mic_scale.scale_widget.get_value ();
             });
 
             main_grid.attach (mic_scale, 0, position++, 1, 1);

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -17,77 +17,59 @@
 
 public class Sound.Widgets.Scale : Gtk.Grid {
     private Gtk.Image image;
-    private Gtk.Switch switch_widget;
-    private Gtk.Scale scale_widget;
+
+    public bool active { get; set; }
+    public Gtk.Scale scale_widget { get; private set; }
 
     public Scale (string icon, bool active = false, double min, double max, double step) {
-        this.hexpand = true;
-        var image_box = new Gtk.EventBox ();
         image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.DIALOG);
-        image_box.halign = Gtk.Align.START;
-        image_box.add (image);
+        image.pixel_size = 48;
 
-        this.attach (image_box, 0, 0, 1, 1);
+        var image_box = new Gtk.EventBox ();
+        image_box.add (image);
 
         scale_widget = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, min, max, step);
         scale_widget.margin_start = 6;
         scale_widget.set_size_request (175, -1);
         scale_widget.set_draw_value (false);
         scale_widget.hexpand = true;
-        this.attach (scale_widget, 1, 0, 1, 1);
 
-        switch_widget = new Gtk.Switch ();
+        var switch_widget = new Gtk.Switch ();
         switch_widget.active = active;
         switch_widget.valign = Gtk.Align.CENTER;
         switch_widget.margin_start = 6;
         switch_widget.margin_end = 12;
 
-        this.attach (switch_widget, 2, 0, 1, 1);
+        hexpand = true;
+        get_style_context ().add_class ("indicator-switch");
+        attach (image_box, 0, 0, 1, 1);
+        attach (scale_widget, 1, 0, 1, 1);
+        attach (switch_widget, 2, 0, 1, 1);
 
-        this.get_style_context ().add_class ("indicator-switch");
+        add_events (Gdk.EventMask.SCROLL_MASK);
+        scroll_event.connect (on_scroll);
 
-        this.add_events (Gdk.EventMask.SCROLL_MASK);
         image_box.add_events (Gdk.EventMask.SCROLL_MASK);
-        switch_widget.add_events (Gdk.EventMask.SCROLL_MASK);
-        // delegate all scroll events to the scale
-        this.scroll_event.connect (on_scroll);
+        image_box.add_events (Gdk.EventMask.BUTTON_RELEASE_MASK);
         image_box.scroll_event.connect (on_scroll);
+        image_box.button_release_event.connect (() => {
+            switch_widget.active = !switch_widget.active;
+            return Gdk.EVENT_STOP;
+        });
+
+        switch_widget.add_events (Gdk.EventMask.SCROLL_MASK);
         switch_widget.scroll_event.connect (on_scroll);
         switch_widget.bind_property ("active", scale_widget, "sensitive", BindingFlags.SYNC_CREATE);
         switch_widget.bind_property ("active", image, "sensitive", BindingFlags.SYNC_CREATE);
-    }
-
-    construct {
-    
+        switch_widget.bind_property ("active", this, "active", BindingFlags.BIDIRECTIONAL);
     }
 
     private bool on_scroll (Gdk.EventScroll event) {
         scale_widget.scroll_event (event);
-
         return Gdk.EVENT_STOP;
-    }
-
-    public Gtk.Image get_image () {
-        return image;
     }
 
     public void set_icon (string icon) {
         image.set_from_icon_name (icon, Gtk.IconSize.DIALOG);
-    }
-
-    public void set_active (bool active) {
-        switch_widget.set_active (active);
-    }
-
-    public bool get_active () {
-        return switch_widget.get_active ();
-    }
-
-    public Gtk.Switch get_switch () {
-        return switch_widget;
-    }
-
-    public Gtk.Scale get_scale () {
-        return scale_widget;
     }
 }

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -42,9 +42,9 @@ public class Sound.Widgets.Scale : Gtk.Grid {
 
         hexpand = true;
         get_style_context ().add_class ("indicator-switch");
-        attach (image_box, 0, 0, 1, 1);
-        attach (scale_widget, 1, 0, 1, 1);
-        attach (switch_widget, 2, 0, 1, 1);
+        add (image_box);
+        add (scale_widget);
+        add (switch_widget);
 
         add_events (Gdk.EventMask.SCROLL_MASK);
         scroll_event.connect (on_scroll);

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2017 elementary LLC. (http://launchpad.net/wingpanel-indicator-sound)
+* Copyright (c) 2015-2018 elementary LLC. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public


### PR DESCRIPTION
Fixes #41 

* Make `scale_widget` public get and remove `get_scale ()`
* Make `active` a public property instead of get/set methods, bind to switch and remove `get_switch ()`
* Organize
* Remove an halign that doesn't do anything since the scale is hexpanded
* Set pixel size on the icon in case of missing scaled icons
* Click the icon to mute and unmute