### PR TITLE
Link against libcanberra-gtk3 and not libcanberra-gtk

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,11 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
 
+add_project_arguments(
+    ['--vapidir', join_paths(meson.current_source_dir(), 'vapi')],
+    language: 'vala'
+)
+
 wingpanel_dep = dependency('wingpanel-2.0')
 
 asresources = gnome.compile_resources(
@@ -39,7 +44,7 @@ shared_module(
         dependency('libpulse-mainloop-glib'),
         dependency('libnotify'),
         dependency('libcanberra'),
-        dependency('libcanberra-gtk'),
+        dependency('libcanberra-gtk3'),
         wingpanel_dep
     ],
     install: true,

--- a/vapi/libcanberra-gtk3.deps
+++ b/vapi/libcanberra-gtk3.deps
@@ -1,0 +1,2 @@
+libcanberra
+gtk+-3.0

--- a/vapi/libcanberra-gtk3.vapi
+++ b/vapi/libcanberra-gtk3.vapi
@@ -1,0 +1,37 @@
+/***
+  This file is part of libcanberra.
+
+  Copyright 2009 Lennart Poettering
+
+  libcanberra is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  libcanberra is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with libcanberra. If not, see
+  <http://www.gnu.org/licenses/>.
+***/
+
+using Canberra;
+using Gdk;
+using Gtk;
+
+[CCode (cprefix = "CA_GTK_", lower_case_cprefix = "ca_gtk_", cheader_filename = "canberra-gtk.h")]
+namespace CanberraGtk {
+
+        public unowned Context? context_get();
+        public unowned Context? context_get_for_screen(Gdk.Screen? screen);
+
+        public int proplist_set_for_widget(Proplist p, Gtk.Widget w);
+        public int play_for_widget(Gtk.Widget w, uint32 id, ...);
+        public int proplist_set_for_event(Proplist p, Gdk.Event e);
+        public int play_for_event(Gdk.Event e, uint32 id, ...);
+
+        public void widget_disable_sounds(Gtk.Widget w, bool enable = false);
+}


### PR DESCRIPTION
Even if they both share the same API and symbols better do it the right way