### PR TITLE
MprisGui: Rewrite using Gtk.Grid

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig <http://EditorConfig.org>
+root = true
+
+# elementary defaults
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+tab_width = 4
+
+[{*.xml,*.xml.in,*.yml}]
+tab_width = 2
+

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -191,6 +191,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Box {
         artist_label.valign = Gtk.Align.START;
 
         var titles = new Gtk.Grid ();
+        titles.column_spacing = 3;
         titles.attach (overlay, 0, 0, 1, 2);
         titles.attach (title_label, 1, 0);
         titles.attach (artist_label, 1, 1);

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -262,7 +262,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Box {
             });
         });
 
-        play_btn.clicked.connect (()=> {
+        play_btn.clicked.connect (() => {
             Idle.add (()=> {
                 if (!Thread.supported ()) {
                     warning ("Threading is not supported. DBus timeout could be blocking UI");

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -164,9 +164,6 @@ public class Sound.Widgets.ClientWidget : Gtk.Box {
     construct {
         load_remote_art_cancel = new Cancellable ();
 
-        player_revealer = new Gtk.Revealer ();
-        player_revealer.reveal_child = true;
-
         background = new Gtk.Image ();
 
         mask = new Gtk.Image.from_resource ("/io/elementary/wingpanel/sound/image-mask.svg");
@@ -216,15 +213,18 @@ public class Sound.Widgets.ClientWidget : Gtk.Box {
         player_box.add (play_btn);
         player_box.add (next_btn);
 
+        player_revealer = new Gtk.Revealer ();
+        player_revealer.reveal_child = true;
+        player_revealer.add (player_box);
+
+        pack_start (player_revealer);
+
         if (client != null) {
             connect_to_client ();
             update_play_status ();
             update_from_meta ();
             update_controls ();
         }
-
-        player_revealer.add (player_box);
-        pack_start (player_revealer);
 
         titles_events.button_press_event.connect (raise_player);
 

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -229,7 +229,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Box {
 
         titles_events.button_press_event.connect (raise_player);
 
-        prev_btn.clicked.connect (()=> {
+        prev_btn.clicked.connect (() => {
             Idle.add (()=> {
                 if (!Thread.supported ()) {
                     warning ("Threading is not supported. DBus timeout could be blocking UI");
@@ -305,7 +305,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Box {
             });
         });
 
-        next_btn.clicked.connect (()=> {
+        next_btn.clicked.connect (() => {
             Idle.add (()=> {
                 if(!Thread.supported ()) {
                     warning ("Threading is not supported. DBus timeout could be blocking UI");


### PR DESCRIPTION
* Use Gtk.Grid instead of nested boxes
* Remove an extra eventbox
* Organize
* Don't do weird stuff with sharing `btn` variables
* Move signals to the end of the `construct` block
* Remove line wrap since labels are ellipsized and they'll never be wrapped