### PR TITLE
Adjust scroll speed over Scale

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -293,8 +293,13 @@ public class Sound.Indicator : Wingpanel.Indicator {
                     dir = -1;
                 }
 
+                var adjusted_volume_step_percentage = volume_step_percentage;
+                if (e.direction == Gdk.ScrollDirection.SMOOTH) {
+                    adjusted_volume_step_percentage = e.delta_y.abs() / 10;
+                }
+
                 double v = volume_scale.scale_widget.get_value ();
-                v = v + volume_step_percentage * dir;
+                v = v + adjusted_volume_step_percentage * dir;
 
                 if (v >= -0.05 && v <= 1.05) {
                     volume_scale.scale_widget.set_value (v);


### PR DESCRIPTION
Fixes: #3

Looks like only scroll direction `Gdk.ScrollDirection.SMOOTH` is triggered over the `Gtk.Scale`, which seems to be triggered more often, but with a delta. This PR uses the delta to adjust the adjusting step.