### PR TITLE
Fix smooth scrolling and horizontal scrolling

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -293,8 +293,13 @@ public class Sound.Indicator : Wingpanel.Indicator {
                     dir = -1;
                 }
 
+                var adjusted_volume_step_percentage = volume_step_percentage;
+                if (e.direction == Gdk.ScrollDirection.SMOOTH) {
+                    adjusted_volume_step_percentage = e.delta_y.abs() / 10;
+                }
+
                 double v = volume_scale.scale_widget.get_value ();
-                v = v + volume_step_percentage * dir;
+                v = v + adjusted_volume_step_percentage * dir;
 
                 if (v >= -0.05 && v <= 1.05) {
                     volume_scale.scale_widget.set_value (v);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -377,7 +377,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
         }
 
         if (total_y_delta.abs () > 0.5) {
-            dir = total_y_delta;
+            dir = natural_scroll ? total_y_delta : -total_y_delta;
         }
 
         if (total_x_delta.abs () > 0.5) {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -410,22 +410,21 @@ public class Sound.Indicator : Wingpanel.Indicator {
             v = volume_control.volume.volume;
         }
 
-        if (change == 0 ||
-            v == 0.0 && change < 0.0 ||
-            v == max_volume && change > 0.0) {
+        var new_v = (v + volume_step_percentage * change).clamp (0.0, max_volume);
 
+        if (new_v == v) {
             /* Ignore if no volume change will result */
             return;
         }
 
-        v = (v + volume_step_percentage * change).clamp (0.0, max_volume);
+
 
         if (is_mic) {
-            volume_control.mic_volume = v;
+            volume_control.mic_volume = new_v;
         } else {
             var vol = new Services.VolumeControl.Volume ();
             vol.reason = Services.VolumeControl.VolumeReasons.USER_KEYPRESS;
-            vol.volume = v;
+            vol.volume = new_v;
             volume_control.volume = vol;
         }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -370,18 +370,22 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
     }
 
-    /* Requires -1 > param < 1 */
     private bool same_sign (double a, double b) {
-        return a == 0.0 || b == 0.0 || Math.floor (a) == Math.floor (b);
+        return a == 0.0 || b == 0.0 || (a > 0.0 && b > 0.0) || (a < 0.0 && b < 0.0);
     }
 
     private void handle_volume_change (double change) {
         double v = volume_control.volume.volume;
-        if (change == 0 || v == 0.0 && change < 0.0 || v == max_volume && change > 0.0) {
+
+        if (change == 0 ||
+            v == 0.0 && change < 0.0 ||
+            v == max_volume && change > 0.0) {
+
+            /* Ignore if no volume change will result */
             return;
         }
 
-        v = (v + 0.06 * change).clamp (0.0, max_volume);
+        v = (v + volume_step_percentage * change).clamp (0.0, max_volume);
 
         var vol = new Services.VolumeControl.Volume ();
         vol.reason = Services.VolumeControl.VolumeReasons.USER_KEYPRESS;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -124,7 +124,10 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
     private void on_mic_volume_change () {
         var volume = volume_control.mic_volume;
-        mic_scale.scale_widget.set_value (volume);
+
+        if (volume != mic_scale.scale_widget.get_value ()) {
+            mic_scale.scale_widget.set_value (volume);
+        }
     }
 
     private void on_mute_change () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -96,9 +96,9 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     ~Indicator () {
-        if (this.sound_was_blocked_timeout_id > 0) {
-            Source.remove (this.sound_was_blocked_timeout_id);
-            this.sound_was_blocked_timeout_id = 0;
+        if (sound_was_blocked_timeout_id > 0) {
+            Source.remove (sound_was_blocked_timeout_id);
+            sound_was_blocked_timeout_id = 0;
         }
     }
 
@@ -110,12 +110,12 @@ public class Sound.Indicator : Wingpanel.Indicator {
             max = cap_volume;
         }
 
-        this.max_volume = max;
+        max_volume = max;
         on_volume_change ();
     }
 
     private void on_volume_change () {
-        double volume = volume_control.volume.volume / this.max_volume;
+        double volume = volume_control.volume.volume / max_volume;
         if (volume != volume_scale.scale_widget.get_value ()) {
             volume_scale.scale_widget.set_value (volume);
             display_widget.icon_name = get_volume_icon (volume);
@@ -145,21 +145,21 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void on_is_playing_change () {
-        if (!this.volume_control.mute) {
-            this.mute_blocks_sound = false;
+        if (!volume_control.mute) {
+            mute_blocks_sound = false;
             return;
         }
-        if (this.volume_control.is_playing) {
-            this.mute_blocks_sound = true;
-        } else if (this.mute_blocks_sound) {
+        if (volume_control.is_playing) {
+            mute_blocks_sound = true;
+        } else if (mute_blocks_sound) {
             /* Continue to show the blocking icon five seconds after a player has tried to play something */
-            if (this.sound_was_blocked_timeout_id > 0) {
-                Source.remove (this.sound_was_blocked_timeout_id);
+            if (sound_was_blocked_timeout_id > 0) {
+                Source.remove (sound_was_blocked_timeout_id);
             }
 
-            this.sound_was_blocked_timeout_id = Timeout.add_seconds (5, () => {
-                this.mute_blocks_sound = false;
-                this.sound_was_blocked_timeout_id = 0;
+            sound_was_blocked_timeout_id = Timeout.add_seconds (5, () => {
+                mute_blocks_sound = false;
+                sound_was_blocked_timeout_id = 0;
                 display_widget.icon_name = get_volume_icon (volume_control.volume.volume);
                 return false;
             });
@@ -178,7 +178,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private void update_mic_visibility () {
-        if (this.volume_control.is_listening) {
+        if (volume_control.is_listening) {
             mic_scale.no_show_all = false;
             mic_scale.show_all();
             mic_separator.no_show_all = false;
@@ -194,8 +194,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
     }
 
     private string get_volume_icon (double volume) {
-        if (volume <= 0 || this.volume_control.mute) {
-            return this.mute_blocks_sound ? "audio-volume-muted-blocking-symbolic" : "audio-volume-muted-symbolic";
+        if (volume <= 0 || volume_control.mute) {
+            return mute_blocks_sound ? "audio-volume-muted-blocking-symbolic" : "audio-volume-muted-symbolic";
         } else if (volume <= 0.3) {
             return "audio-volume-low-symbolic";
         } else if (volume <= 0.7) {
@@ -255,10 +255,10 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
             volume_scale.scale_widget.value_changed.connect (() => {
                 var vol = new Services.VolumeControl.Volume();
-                var v = volume_scale.scale_widget.get_value () * this.max_volume;
-                vol.volume = v.clamp (0.0, this.max_volume);
+                var v = volume_scale.scale_widget.get_value () * max_volume;
+                vol.volume = v.clamp (0.0, max_volume);
                 vol.reason = Services.VolumeControl.VolumeReasons.USER_KEYPRESS;
-                this.volume_control.volume = vol;
+                volume_control.volume = vol;
                 volume_scale.icon = get_volume_icon (volume_scale.scale_widget.get_value ());
             });
 
@@ -389,8 +389,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
         var vol = new Services.VolumeControl.Volume ();
         vol.reason = Services.VolumeControl.VolumeReasons.USER_KEYPRESS;
-        vol.volume = v.clamp (0.0, this.max_volume);
-        this.volume_control.volume = vol;
+        vol.volume = v;
+        volume_control.volume = vol;
         play_sound_blubble ();
     }
 
@@ -456,11 +456,11 @@ public class Sound.Indicator : Wingpanel.Indicator {
         if (notification != null) {
             string icon = get_volume_icon (volume_scale.scale_widget.get_value ());
 
-            this.notification.update ("indicator-sound", "", icon);
-            this.notification.set_hint ("value", new Variant.int32 (
-                (int32)Math.round(volume_control.volume.volume / this.max_volume * 100.0)));
+            notification.update ("indicator-sound", "", icon);
+            notification.set_hint ("value", new Variant.int32 (
+                (int32)Math.round(volume_control.volume.volume / max_volume * 100.0)));
             try {
-                this.notification.show ();
+                notification.show ();
             } catch (Error e) {
                 warning ("Unable to show sound notification: %s", e.message);
                 notification = null;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -383,6 +383,9 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
         dir = total_x_delta.abs () > total_y_delta.abs () ? total_x_delta : total_y_delta;
 
+        /* Check that there has been a significant change in the same direction as last
+         * time, in order to reduce fluctuating changes.
+         */
         if (dir.abs () > 0.2 && same_sign (dir, last_dir)) {
             total_x_delta = 0.0;
             total_y_delta = 0.0;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -325,7 +325,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
         switch (e.direction) {
             case Gdk.ScrollDirection.SMOOTH:
                 if (same_sign (e.delta_x, total_x_delta)) {
-                    total_x_delta += e.delta_x;
+                    total_x_delta += natural_scroll ? -e.delta_x : e.delta_x;
                 } else {
                     total_x_delta = 0;
                 }
@@ -346,11 +346,11 @@ public class Sound.Indicator : Wingpanel.Indicator {
                 total_x_delta = 0.0;
                 break;
             case Gdk.ScrollDirection.LEFT:
-                total_x_delta = -1.0;
+                total_x_delta = natural_scroll ? 1.0 : -1.0;
                 total_y_delta = 0.0;
                 break;
             case Gdk.ScrollDirection.RIGHT:
-                total_x_delta = 1.0;
+                total_x_delta = natural_scroll ? -1.0 : 1.0;
                 total_y_delta = 0.0;
                 break;
             default:
@@ -358,11 +358,6 @@ public class Sound.Indicator : Wingpanel.Indicator {
         }
 
         dir = total_x_delta.abs () > total_y_delta.abs () ? total_x_delta : total_y_delta;
-
-        /* DO not honor natural scroll setting */
-        if (natural_scroll) {
-            dir *= -1.0;
-        }
 
         if (dir.abs () > 0.2 && same_sign (dir, last_dir)) {
             total_x_delta = 0.0;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -18,7 +18,6 @@
 public class DisplayWidget : Gtk.Grid {
     public bool show_mic { get; set; }
     public string icon_name { get; set; }
-    private bool ignore_next_event = false;
 
     public signal void volume_scroll_event (Gdk.EventScroll e);
     public signal void mic_scroll_event (Gdk.EventScroll e);
@@ -43,7 +42,8 @@ public class DisplayWidget : Gtk.Grid {
          * entirely clear.  Only normal scroll events are received even if the SMOOTH_SCROLL_MASK
          * is set. */
         scroll_event.connect ((e) => {
-            if (!ignore_scroll_event (e)) {
+            /* Ignore horizontal scrolling on wingpanel indicator */
+            if (e.direction != Gdk.ScrollDirection.LEFT && e.direction != Gdk.ScrollDirection.RIGHT) {
                 /* Determine whether scrolling on mic icon or not */
                 if (show_mic && e.x < mic_icon.pixel_size + mic_icon.margin_end) {
                     mic_scroll_event (e);
@@ -57,24 +57,5 @@ public class DisplayWidget : Gtk.Grid {
 
         bind_property ("icon-name", volume_icon, "icon-name", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
         bind_property ("show-mic", mic_revealer, "reveal-child", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
-    }
-
-    /* Diagonal scrolling causes a mixture of horizontal and vertical events.
-     * We ignore horizontal and "impure" scrolling by only passing on every other vertical event.
-     * This avoids jerky changes when horizontal scrolling with touchpad is attempted.
-     */
-    private bool ignore_scroll_event (Gdk.EventScroll e) {
-        if (ignore_next_event) {
-            ignore_next_event = false;
-            return true;
-        } else {
-            ignore_next_event = true;
-        }
-
-        if (e.direction == Gdk.ScrollDirection.LEFT || e.direction == Gdk.ScrollDirection.RIGHT) {
-            return true;
-        } else {
-            return false;
-        }
     }
 }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -15,11 +15,12 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-public class DisplayWidget : Gtk.Grid {
+public class DisplayWidget : Gtk.EventBox {
     public bool show_mic { get; set; }
     public string icon_name { get; set; }
 
     construct {
+        var grid = new Gtk.Grid ();
         var volume_icon = new Gtk.Image ();
         volume_icon.pixel_size = 24;
 
@@ -31,8 +32,20 @@ public class DisplayWidget : Gtk.Grid {
         mic_revealer.add (mic_icon);
 
         valign = Gtk.Align.CENTER;
-        add (mic_revealer);
-        add (volume_icon);
+        grid.add (mic_revealer);
+        grid.add (volume_icon);
+        add (grid);
+
+        set_events (Gdk.EventMask.SMOOTH_SCROLL_MASK);
+
+        scroll_event.connect ((e) => {
+            /* Ignore horizontal scrolling unless smooth to avoid jerky changes cause by separate events for each axis */
+            if (e.direction == Gdk.ScrollDirection.LEFT || e.direction == Gdk.ScrollDirection.RIGHT) {
+                return true;
+            } else {
+                return false;
+            }
+        });
 
         bind_property ("icon-name", volume_icon, "icon-name", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
         bind_property ("show-mic", mic_revealer, "reveal-child", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -46,7 +46,7 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
     }
 
     construct {
-        set_above_child (true);
+        set_above_child (false);
         var grid = new Gtk.Grid ();
         image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.DIALOG);
         image.pixel_size = 48;
@@ -78,6 +78,12 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
         image_box.button_release_event.connect (() => {
             switch_widget.active = !switch_widget.active;
             return Gdk.EVENT_STOP;
+        });
+
+        scale_widget.scroll_event.connect ((e) => {
+            /* Re-emit the signal on the eventbox instead of using native handler */
+            scroll_event (e);
+            return true;
         });
 
         switch_widget.bind_property ("active", scale_widget, "sensitive", BindingFlags.SYNC_CREATE);

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -15,7 +15,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-public class Sound.Widgets.Scale : Gtk.Grid {
+public class Sound.Widgets.Scale : Gtk.EventBox {
     private Gtk.Image image;
 
     private string _icon;
@@ -46,6 +46,8 @@ public class Sound.Widgets.Scale : Gtk.Grid {
     }
 
     construct {
+        set_above_child (true);
+        var grid = new Gtk.Grid ();
         image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.DIALOG);
         image.pixel_size = 48;
 
@@ -63,32 +65,23 @@ public class Sound.Widgets.Scale : Gtk.Grid {
         switch_widget.margin_start = 6;
         switch_widget.margin_end = 12;
 
-        hexpand = true;
-        get_style_context ().add_class ("indicator-switch");
-        add (image_box);
-        add (scale_widget);
-        add (switch_widget);
+        grid.hexpand = true;
+        grid.get_style_context ().add_class ("indicator-switch");
+        grid.add (image_box);
+        grid.add (scale_widget);
+        grid.add (switch_widget);
 
-        add_events (Gdk.EventMask.SCROLL_MASK);
-        scroll_event.connect (on_scroll);
+        add (grid);
+        add_events (Gdk.EventMask.SMOOTH_SCROLL_MASK);
 
-        image_box.add_events (Gdk.EventMask.SCROLL_MASK);
         image_box.add_events (Gdk.EventMask.BUTTON_RELEASE_MASK);
-        image_box.scroll_event.connect (on_scroll);
         image_box.button_release_event.connect (() => {
             switch_widget.active = !switch_widget.active;
             return Gdk.EVENT_STOP;
         });
 
-        switch_widget.add_events (Gdk.EventMask.SCROLL_MASK);
-        switch_widget.scroll_event.connect (on_scroll);
         switch_widget.bind_property ("active", scale_widget, "sensitive", BindingFlags.SYNC_CREATE);
         switch_widget.bind_property ("active", image, "sensitive", BindingFlags.SYNC_CREATE);
         switch_widget.bind_property ("active", this, "active", BindingFlags.BIDIRECTIONAL);
-    }
-
-    private bool on_scroll (Gdk.EventScroll event) {
-        scale_widget.scroll_event (event);
-        return Gdk.EVENT_STOP;
     }
 }


### PR DESCRIPTION
Fixes #71 
Fixes #39 
Fixes #31 
Fixes #3 
Fixes #2 

Scroll events from the icon and the scale widgets are provided only by a surrounding event box - rather than from individual child widgets  - and smooth scrolling is enabled (but only has effect for the scale widget).  

The same function processes events from both sources to provide a volume direction change as a double between -1.0 and +1.0 allowing fine control.

To avoid fluctuations, small deltas are accumulated and rapid direction changes ignored.

The effect of the `natural_scrolling` setting is negated so that horizontal scrolling always has the expected effect on the scale.