### PR TITLE
Support horizontal scroll on icon?

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -39,17 +39,14 @@ public class DisplayWidget : Gtk.Grid {
         add (volume_icon);
 
         /* SMOOTH_SCROLL_MASK has no effect on this widget for reasons that are not
-         * entirely clear.  Only normal scroll events are received even if the SMOOTH_SCROLL_MASK
+         * entirely clear. Only normal scroll events are received even if the SMOOTH_SCROLL_MASK
          * is set. */
         scroll_event.connect ((e) => {
-            /* Ignore horizontal scrolling on wingpanel indicator */
-            if (e.direction != Gdk.ScrollDirection.LEFT && e.direction != Gdk.ScrollDirection.RIGHT) {
-                /* Determine whether scrolling on mic icon or not */
-                if (show_mic && e.x < mic_icon.pixel_size + mic_icon.margin_end) {
-                    mic_scroll_event (e);
-                } else {
-                    volume_scroll_event (e);
-                }
+            /* Determine whether scrolling on mic icon or not */
+            if (show_mic && e.x < mic_icon.pixel_size + mic_icon.margin_end) {
+                mic_scroll_event (e);
+            } else {
+                volume_scroll_event (e);
             }
 
             return true;


### PR DESCRIPTION
It's possible to control the input and output volume by scrolling vertically over the indicator icons, but currently we limit this to vertical scroll only. 

We do this by checking the event e.direction (Gdk.ScrollDirection), but this still triggers some volume changes while scrolling horizontally. See: https://github.com/elementary/wingpanel-indicator-sound/pull/81#issuecomment-437080133

@elementary/ux Should we also support horizontal scrolling on the indicator icons?