### PR TITLE
Fixed music player fallback icon logic

### DIFF
--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -37,7 +37,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
     private Gtk.Button prev_btn;
     private Gtk.Button play_btn;
     private Gtk.Button next_btn;
-    private Icon? app_icon = null;
+    private Icon app_icon;
     private Cancellable load_remote_art_cancel;
 
     private bool launched_by_indicator = false;
@@ -58,13 +58,10 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                 if (app_name == "") {
                     app_name = ainfo.get_name ();
                 }
-
-                app_icon = value.get_icon ();
-                if (app_icon == null) {
-                    app_icon = new ThemedIcon ("application-default-icon");
+                if (value.get_icon () != null) {
+                    app_icon = value.get_icon ();
+                    background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
                 }
-
-                background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
             }
         }
     }
@@ -169,6 +166,8 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
     }
 
     construct {
+        app_icon = new ThemedIcon ("multimedia-audio-player");
+
         load_remote_art_cancel = new Cancellable ();
 
         background = new Gtk.Image ();

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -58,8 +58,9 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                 if (app_name == "") {
                     app_name = ainfo.get_name ();
                 }
-                if (value.get_icon () != null) {
-                    app_icon = value.get_icon ();
+                var icon = value.get_icon ();
+                if (icon != null) {
+                    app_icon = icon;
                     background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
                 }
             }

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -171,6 +171,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
         load_remote_art_cancel = new Cancellable ();
 
         background = new Gtk.Image ();
+        background.pixel_size = ICON_SIZE;
 
         mask = new Gtk.Image.from_resource ("/io/elementary/wingpanel/sound/image-mask.svg");
         mask.no_show_all = true;


### PR DESCRIPTION
Fixes: #60 
In the case of Spotify the `app_info` property was never set, never triggering setting the fallback icon.

I've also changed the default icon from `application-default-icon` to `multimedia-audio-player`, because that seemed like a better fallback.

Before:
![fallback icon issue](https://user-images.githubusercontent.com/523210/52378375-c795eb80-2a67-11e9-967b-72414a2f27fa.gif)
After: 
![fixed fallback icon](https://user-images.githubusercontent.com/523210/52378395-d11f5380-2a67-11e9-999a-95e813566e3f.gif)

(No clue why the order of media players suddenly changed)