### PR TITLE
Only update art when url changed

### DIFF
--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -505,8 +505,10 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
         var metadata = client.player.metadata;
         if  ("mpris:artUrl" in metadata) {
             var url = metadata["mpris:artUrl"].get_string ();
-            last_artUrl = url;
-            update_art (url);
+            if (url != last_artUrl) {
+                update_art (url);
+                last_artUrl = url;
+            }
         } else {
             last_artUrl = "";
             background.pixel_size = ICON_SIZE;


### PR DESCRIPTION
While looking into https://github.com/elementary/wingpanel-indicator-sound/issues/60 I noticed that `update_from_meta` is called in rapid succession when the song is changed, this caused the art image to be loaded in rapid succession but while also cancelling the previous load attempt. This caused 6 loads and cancels before the art image was loaded successfully, causing a noticeable delay. With this PR we only update (load) the art when the url changed. 

Before:
![screen record from 2019-02-07 00 52 37](https://user-images.githubusercontent.com/523210/52381913-9de2c180-2a73-11e9-822a-4d9015d00574.gif)
After:
![screen record from 2019-02-07 00 54 05](https://user-images.githubusercontent.com/523210/52381925-a509cf80-2a73-11e9-84bb-2cdbd8e01775.gif)
