### PR TITLE
build: fix install path for wingpanel indicator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,10 @@ gettext_name = meson.project_name() + '-indicator'
 gnome = import('gnome')
 i18n = import('i18n')
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
 
 add_project_arguments(
@@ -57,7 +61,7 @@ shared_module(
 
 install_data(
     'data/io.elementary.desktop.wingpanel.sound.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )
 
 subdir('po')

--- a/meson.build
+++ b/meson.build
@@ -19,13 +19,14 @@ add_project_arguments(
     language: 'vala'
 )
 
-wingpanel_dep = dependency('wingpanel-2.0', version: '>=2.1.0')
-
 asresources = gnome.compile_resources(
     'as-resources', 'data/mask.gresource.xml',
     source_dir: 'data',
     c_name: 'as'
 )
+
+wingpanel_dep = dependency('wingpanel-2.0', version: '>=2.1.0')
+wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
 
 shared_module(
     meson.project_name(),
@@ -56,7 +57,7 @@ shared_module(
         wingpanel_dep
     ],
     install: true,
-    install_dir : wingpanel_dep.get_pkgconfig_variable('indicatorsdir')
+    install_dir : wingpanel_indicatorsdir,
 )
 
 install_data(


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this wingpanel_dep.get_pkgconfig_variable will return a
path from within wingpanel's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.