### PR TITLE
:shirt: Lint widgets directory with vala-lint

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -75,8 +75,18 @@ public class DisplayWidget : Gtk.Grid {
             return Gdk.EVENT_PROPAGATE;
         });
 
-        bind_property ("icon-name", volume_icon, "icon-name", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
-        bind_property ("show-mic", mic_revealer, "reveal-child", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
+        bind_property (
+            "icon-name",
+            volume_icon,
+            "icon-name",
+            GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE
+        );
+        bind_property (
+            "show-mic",
+            mic_revealer,
+            "reveal-child",
+            GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE
+        );
 
         notify["mic-muted"].connect (() => {
             if (mic_muted) {

--- a/src/Widgets/MaxWidthLabel.vala
+++ b/src/Widgets/MaxWidthLabel.vala
@@ -18,10 +18,10 @@
 public class MaxWidthLabel : Gtk.Label {
     private int max_width;
 
-    public MaxWidthLabel(int max_width) {
+    public MaxWidthLabel (int max_width) {
         this.max_width = max_width;
         // Fix this when on gtk 3.16
-        this.set("xalign", 0);
+        this.set ("xalign", 0);
     }
 
     public override void get_preferred_width (out int minimum_width, out int natural_width) {

--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -42,7 +42,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
 
     private bool launched_by_indicator = false;
     private string app_name = _("Music player");
-    private string last_artUrl;
+    private string last_art_url;
 
     public string mpris_name = "";
 
@@ -77,7 +77,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
             this.client_ = value;
             if (value != null) {
                 string? desktop_entry = client.player.desktop_entry;
-                if  (desktop_entry != null && desktop_entry != "") {
+                if (desktop_entry != null && desktop_entry != "") {
                     app_info = new DesktopAppInfo ("%s.desktop".printf (desktop_entry));
                 }
 
@@ -91,7 +91,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                         try {
                             launched_by_indicator = false;
                             client.player.play_pause ();
-                        } catch  (Error e) {
+                        } catch (Error e) {
                             warning ("Could not play/pause: %s", e.message);
                         }
 
@@ -99,14 +99,17 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                     });
                 }
             } else {
-                (play_btn.get_image () as Gtk.Image).set_from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                    "media-playback-start-symbolic",
+                    Gtk.IconSize.LARGE_TOOLBAR
+                );
                 prev_btn.sensitive = false;
                 next_btn.sensitive = false;
                 Sound.Services.Settings.get_instance ().last_title_info = {
                     app_info.get_id (),
                     title_label.get_text (),
                     artist_label.get_text (),
-                    last_artUrl
+                    last_art_url
                 };
                 this.mpris_name = "";
             }
@@ -187,7 +190,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
         overlay.add_overlay (mask);
 
         var markup_attribute = new Pango.AttrList ();
-        markup_attribute.insert(Pango.attr_weight_new (Pango.Weight.BOLD));
+        markup_attribute.insert (Pango.attr_weight_new (Pango.Weight.BOLD));
 
         title_label = new MaxWidthLabel (MAX_WIDTH_TITLE);
         title_label.ellipsize = Pango.EllipsizeMode.END;
@@ -244,7 +247,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                         } else if (mp_client != null) {
                             mp_client.previous ();
                         }
-                    } catch  (Error e) {
+                    } catch (Error e) {
                         warning ("Going to previous track probably failed (faulty MPRIS interface): %s", e.message);
                     }
                 } else {
@@ -345,10 +348,10 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
     }
 
     private void connect_to_client () {
-        client.prop.properties_changed.connect ((i,p,inv) => {
+        client.prop.properties_changed.connect ((i, p, inv) => {
             if (i == "org.mpris.MediaPlayer2.Player") {
                 /* Handle mediaplayer2 iface */
-                p.foreach ((k,v) => {
+                p.foreach ((k, v) => {
                     if (k == "Metadata") {
                         Idle.add (() => {
                             update_from_meta ();
@@ -378,7 +381,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                     warning ("Threading is not supported. DBus timeout could be blocking UI");
                     try {
                         client.player.raise ();
-                    } catch  (Error e) {
+                    } catch (Error e) {
                         warning ("Raising the player probably failed (faulty MPRIS interface): %s", e.message);
                     }
                 } else {
@@ -428,13 +431,19 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
      * Update play status based on player requirements
      */
     private void update_play_status () {
-        switch  (client.player.playback_status) {
+        switch (client.player.playback_status) {
             case "Playing":
-                (play_btn.get_image () as Gtk.Image).set_from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                    "media-playback-pause-symbolic",
+                    Gtk.IconSize.LARGE_TOOLBAR
+                );
                 break;
             default:
                 /* Stopped, Paused */
-                (play_btn.get_image () as Gtk.Image).set_from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                    "media-playback-start-symbolic",
+                    Gtk.IconSize.LARGE_TOOLBAR
+                );
                 break;
         }
     }
@@ -465,7 +474,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
             return;
         }
 
-        if (uri.has_prefix  ("file://")) {
+        if (uri.has_prefix ("file://")) {
             string fname = uri.split ("file://")[1];
             try {
                 var pbuf = new Gdk.Pixbuf.from_file_at_size (fname, ICON_SIZE * scale, ICON_SIZE * scale);
@@ -473,7 +482,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
                 background.get_style_context ().set_scale (1);
                 mask.no_show_all = false;
                 mask.show ();
-            } catch  (Error e) {
+            } catch (Error e) {
                 //background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
             }
         } else {
@@ -508,14 +517,14 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
      */
     protected void update_from_meta () {
         var metadata = client.player.metadata;
-        if  ("mpris:artUrl" in metadata) {
+        if ("mpris:artUrl" in metadata) {
             var url = metadata["mpris:artUrl"].get_string ();
-            if (url != last_artUrl) {
+            if (url != last_art_url) {
                 update_art (url);
-                last_artUrl = url;
+                last_art_url = url;
             }
         } else {
-            last_artUrl = "";
+            last_art_url = "";
             background.pixel_size = ICON_SIZE;
             background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
             mask.no_show_all = true;
@@ -523,7 +532,7 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
         }
 
         string title;
-        if  ("xesam:title" in metadata && metadata["xesam:title"].is_of_type (VariantType.STRING)
+        if ("xesam:title" in metadata && metadata["xesam:title"].is_of_type (VariantType.STRING)
             && metadata["xesam:title"].get_string () != "") {
             title = metadata["xesam:title"].get_string ();
         } else {
@@ -532,11 +541,11 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
 
         title_label.label = title;
 
-        if  ("xesam:artist" in metadata && metadata["xesam:artist"].is_of_type (VariantType.STRING_ARRAY)) {
+        if ("xesam:artist" in metadata && metadata["xesam:artist"].is_of_type (VariantType.STRING_ARRAY)) {
             (unowned string)[] artists = metadata["xesam:artist"].get_strv ();
             artist_label.label = string.joinv (", ", artists);
         } else {
-            if  (client.player.playback_status == "Playing") {
+            if (client.player.playback_status == "Playing") {
                 artist_label.label = _("Unknown Title");
             } else {
                 artist_label.label = NOT_PLAYING;
@@ -570,11 +579,17 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
         if (playing != "") {
             switch (playing) {
                 case "playing":
-                    (play_btn.get_image () as Gtk.Image).set_from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                    (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                        "media-playback-pause-symbolic",
+                        Gtk.IconSize.LARGE_TOOLBAR
+                    );
                     break;
                 default:
                     /* Stopped, Paused */
-                    (play_btn.get_image () as Gtk.Image).set_from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                    (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                        "media-playback-start-symbolic",
+                        Gtk.IconSize.LARGE_TOOLBAR
+                    );
                     break;
             }
         }


### PR DESCRIPTION
This fixes linting errors in the src/Widgets directory.

## Run vala-lint locally:

Assuming you have [vala-lint](https://github.com/elementary/vala-lint) installed locally:
```sh
io.elementary.vala-lint -d src/Widgets
```

## Run vala-lint via a container:
Assuming you have docker installed locally:
```sh
docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint io.elementary.vala-lint -d src/Widgets
```

This is step 1 of getting #113 set up