### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/Widgets/MprisGui.vala
+++ b/src/Widgets/MprisGui.vala
@@ -561,14 +561,14 @@ public class Sound.Widgets.ClientWidget : Gtk.Grid {
         if (playing != "") {
             switch (playing) {
                 case "playing":
-                    (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                    ((Gtk.Image)play_btn.image).set_from_icon_name (
                         "media-playback-pause-symbolic",
                         Gtk.IconSize.LARGE_TOOLBAR
                     );
                     break;
                 default:
                     /* Stopped, Paused */
-                    (play_btn.get_image () as Gtk.Image).set_from_icon_name (
+                    ((Gtk.Image)play_btn.image).set_from_icon_name (
                         "media-playback-start-symbolic",
                         Gtk.IconSize.LARGE_TOOLBAR
                     );


### PR DESCRIPTION
This seems to be the code path that updates the icon for bluetooth devices when the play/pause. I've tested with my phone that the icon still correctly updates when you play/pause on the phone.