### PR TITLE
Release 2.1.7

### DIFF
--- a/data/sound.appdata.xml.in
+++ b/data/sound.appdata.xml.in
@@ -7,6 +7,15 @@
   <summary>Adjust speaker and microphone volume or see Now Playing information and media controls</summary>
   <icon type="stock">preferences-desktop-sound</icon>
   <releases>
+    <release version="2.1.7" date="2020-10-08" urgency="medium">
+      <description>
+        <p>Minor updates</p>
+        <ul>
+          <li>Fix opacity flash during icon animation</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.1.6" date="2020-08-07" urgency="medium">
       <description>
         <p>Update default music player when changed</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'sound',
     'vala', 'c',
-    version: '2.1.6'
+    version: '2.1.7'
 )
 
 gettext_name = meson.project_name() + '-indicator'


### PR DESCRIPTION
It's been a while, there are translation updates, we're still compatible with 5.x, and we had a nice subtle fix.

https://github.com/elementary/wingpanel-indicator-sound/compare/2.1.6...release-2.1.7