### PR TITLE
PlayerList: Fix always updating the default player

### DIFF
--- a/src/Widgets/PlayerList.vala
+++ b/src/Widgets/PlayerList.vala
@@ -70,7 +70,7 @@ public class Sound.Widgets.PlayerList : Gtk.Box {
 
     public void update_default_player () {
         var new_player = AppInfo.get_default_for_type ("audio/x-vorbis+ogg", false);
-        if (new_player != null && (new_player != default_player)) {
+        if (new_player != null && (default_player == null || new_player.get_id () != default_player.get_id ())) {
             default_player = new_player;
 
             if (default_widget != null) {


### PR DESCRIPTION
Seems like the default player is updated every time on opening the indicator with the current code. This PR make sure to perform updating only when the indicator is opened in the first time or when the desktop ids don't match

## Before
![Screen record from 2020-10-17 21 53 55](https://user-images.githubusercontent.com/26003928/96337623-6d19b300-10c3-11eb-9cda-6a5686a7da7f.gif)

After opening the default app from indicator, the indicator does not set the song info

## After
![Screen record from 2020-10-17 21 54 38](https://user-images.githubusercontent.com/26003928/96337630-77d44800-10c3-11eb-8e88-2a641af5f3a5.gif)

After opening the default app from indicator, the indicator set the song info correctly
