### PR TITLE
Redirect broken Spotify album artwork URLs

### DIFF
--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -467,6 +467,11 @@ public class Sound.Widgets.PlayerRow : Gtk.Grid {
             } catch (Error e) {
                 //background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
             }
+        } else if (uri.has_prefix ("https://open.spotify.com/image/")) {
+            string fixed = uri.replace ("https://open.spotify.com/", "https://i.scdn.co/")
+            load_remote_art_cancel.cancel ();
+            load_remote_art_cancel.reset ();
+            load_remote_art.begin (fixed);
         } else {
             load_remote_art_cancel.cancel ();
             load_remote_art_cancel.reset ();

--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -468,7 +468,7 @@ public class Sound.Widgets.PlayerRow : Gtk.Grid {
                 //background.set_from_gicon (app_icon, Gtk.IconSize.DIALOG);
             }
         } else if (uri.has_prefix ("https://open.spotify.com/image/")) {
-            string fixed = uri.replace ("https://open.spotify.com/", "https://i.scdn.co/")
+            string fixed = uri.replace ("https://open.spotify.com/", "https://i.scdn.co/");
             load_remote_art_cancel.cancel ();
             load_remote_art_cancel.reset ();
             load_remote_art.begin (fixed);


### PR DESCRIPTION
The Spotify client currently sends an invalid (404) URL in the mpris:artUrl metadata. There is some discussion around this issue on the [Spotify Community](https://community.spotify.com/t5/Desktop-Linux/MPRIS-cover-art-url-file-not-found/td-p/4920104).

Example:

- Invalid, sent in mpris:artUrl: https://open.spotify.com/image/ab67616d00001e02754b2fddebe7039fdb912837
- Valid: https://i.scdn.co/image/ab67616d00001e02754b2fddebe7039fdb912837

This branch simply rewrites the invalid Spotify URLs. Please let me know if this is something you'd want to apply or if I need to make further changes.

Closes #145 