### PR TITLE
Hide temporary MPRIS players that are stopped

### DIFF
--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -428,6 +428,19 @@ public class Sound.Widgets.PlayerRow : Gtk.Grid {
         } else {
             ((Gtk.Image) play_btn.image).icon_name = "media-playback-start-symbolic";
         }
+
+        /**
+         * If a player is no longer playing and doesn't have a desktop info,
+         * hide it since it offers no value to display it. This applies for web
+         * browsers, but in theory any app could have temporary MPRIS playback.
+         */
+        if (client.player.playback_status == "Stopped" && app_info == null) {
+            no_show_all = true;
+            hide ();
+        } else {
+            no_show_all = false;
+            show ();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR hides MPRIS players with a "Stopped" (vs "Playing" or "Paused") playback status and no desktop entry. This matches the temporary MPRIS players that browsers create when viewing content, and theoretically any app that creates a temporary MPRIS-enabled player. I don't think there's a use case for a stopped, unidentified MPRIS player, so this should be a safe patch. Let me know if you think otherwise!

[MediaPlayer2 Spec Playback Status](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Enum:Playback_Status)

Fixes #148