### PR TITLE
appdata: fix HTML syntax (li tag outside ul tag)

### DIFF
--- a/data/sound.appdata.xml.in
+++ b/data/sound.appdata.xml.in
@@ -10,7 +10,9 @@
     <release version="6.0.0" date="2021-07-14" urgency="medium">
       <description>
         <p>New features</p>
+        <ul>
           <li>select specific input and output devices</li>
+        </ul>
         <p>Minor updates</p>
         <ul>
           <li>Hide temporary audio players when they stop</li>


### PR DESCRIPTION
Fixes invalid HTML in appdata. Found via appdata validation.
Rendering glitch caused by invalid HTML can also be seen in the release notes for 6.0.0 on github generated by the release action.