### PR TITLE
MediaPlayer: Give type field valid name

### DIFF
--- a/src/Services/MediaPlayer.vala
+++ b/src/Services/MediaPlayer.vala
@@ -30,7 +30,7 @@ public interface Sound.Services.MediaPlayer : Object {
 
     public abstract string name { owned get; }
     [DBus (name = "Type")]
-    public abstract string _type { owned get; }
+    public abstract string mediaplayer_type { owned get; }
     public abstract string subtype { owned get; }
     public abstract uint position { get; }
     public abstract string status { owned get; }


### PR DESCRIPTION
Fixes #219 

We can't use `type` directly as that causes conflicts with GObject `get_type` methods. Since Vala 0.53, it has started enforcing that property names have to start with a letter.