### PR TITLE
PulseAudioManager: Provide a fallback icon in case none is available

### DIFF
--- a/src/Services/PulseAudioManager.vala
+++ b/src/Services/PulseAudioManager.vala
@@ -558,6 +558,11 @@ public class Sound.PulseAudioManager : GLib.Object {
                 device.icon_name = card.proplist.gets (PulseAudio.Proplist.PROP_DEVICE_ICON_NAME);
             }
 
+            // Fallback to a generic icon name
+            if (device.icon_name == null) {
+                device.icon_name = is_input ? "audio-input-microphone" : "audio-speakers";
+            }
+
             // audio card is currently represented by a speaker
             if (is_input && device.icon_name.has_prefix ("audio-card")) {
                 device.icon_name = "audio-input-microphone";


### PR DESCRIPTION
Same as https://github.com/elementary/switchboard-plug-sound/pull/219