### PR TITLE
Fix loading albumArt from Chromium MPRIS

### DIFF
--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -496,12 +496,12 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
             * To be reviewed in future.
             */
             if (! FileUtils.test (fname, FileTest.EXISTS)) {
-                Regex temp_regex = @/^(\/tmp\/\.)(?P<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$/;
+                Regex temp_regex = /^(\/tmp\/\.)(?P<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$/;
                 MatchInfo regex_match;
-                if (temp_regex.match (fname, 0, out info)) {
-                    var app_name = info.fetch_named ("appName");
+                if (temp_regex.match (fname, 0, out regex_match)) {
+                    var app_name = regex_match.fetch_named ("appName");
 
-                    fname = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_user_runtime_dir (), ".flatpak", appName, fname);
+                    fname = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_user_runtime_dir (), ".flatpak", app_name, fname);
                 }
             }
 

--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -496,10 +496,10 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
             * To be reviewed in future.
             */
             if (! FileUtils.test (fname, FileTest.EXISTS)) {
-                Regex tempAppFolderRegex = /^(\/tmp\/\.)(?P<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$/;
-                MatchInfo info;
-                if(tempAppFolderRegex.match(fname, 0, out info)) {
-                    var appName = info.fetch_named("appName");
+                Regex temp_regex = @/^(\/tmp\/\.)(?P<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$/;
+                MatchInfo regex_match;
+                if (temp_regex.match (fname, 0, out info)) {
+                    var app_name = info.fetch_named ("appName");
 
                     fname = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_user_runtime_dir (), ".flatpak", appName, fname);
                 }

--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -482,6 +482,15 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
 
         if (uri.has_prefix ("file://")) {
             string fname = uri.split ("file://")[1];
+
+            /**
+            * If a MPRIS source is Google Chrome, we can see strange file uri "file:///tmp/.com.google.Chrome.{Hash}",
+            * being stored in runtime directory, and we should handle it properly to display albumArt.
+            */
+            if (fname.has_prefix ("/tmp/.com.google.Chrome")) {
+                fname = GLib.Environment.get_user_runtime_dir () + "/.flatpak/com.google.Chrome" + fname;
+            }
+
             try {
                 var pbuf = new Gdk.Pixbuf.from_file_at_size (fname, ICON_SIZE * scale, ICON_SIZE * scale);
                 background.gicon = mask_pixbuf (pbuf, scale);

--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -484,11 +484,25 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
             string fname = uri.split ("file://")[1];
 
             /**
-            * For some MPRIS sources, we can see strange file uri like "file:///tmp/.com.google.Chrome.{Hash}",
-            * files being stored in users runtime directory, and we should handle it properly to display albumArt.
+            * For some MPRIS sources, e.g. flatpak based Chromium, we can see strange file uri like "file:///tmp/.com.google.Chrome.{Hash}",
+            * but files being stored in users runtime directory, and we should handle it properly to display albumArt.
+            * According to MPRIS spec (https://specifications.freedesktop.org/mpris-spec/latest/#Bus-Name-Policy)
+            * we wont get actual app name, because chrome developers set it to `chromium` as DBUS name,
+            * e.g. 'org.mpris.MediaPlayer2.chromium.instance33959'. But it has no connection to actual app name and files folder.
+            *
+            * Tested version of Chrom(e/ium): 129.0.6668.100
+            * One of possible solutions: to use RegExp.
+            *
+            * To be reviewed in future.
             */
             if (! FileUtils.test (fname, FileTest.EXISTS)) {
-                fname = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_user_runtime_dir (), ".flatpak", "com.google.Chrome", fname);
+                Regex tempAppFolderRegex = /^(\/tmp\/\.)(?P<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$/;
+                MatchInfo info;
+                if(tempAppFolderRegex.match(fname, 0, out info)) {
+                    var appName = info.fetch_named("appName");
+
+                    fname = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_user_runtime_dir (), ".flatpak", appName, fname);
+                }
             }
 
             try {

--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -496,7 +496,8 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
             * To be reviewed in future.
             */
             if (! FileUtils.test (fname, FileTest.EXISTS)) {
-                Regex temp_regex = /^(\/tmp\/\.)(?P<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$/;
+                string folder_pattern = "^(/tmp/.)(?<appName>([a-zA-Z]*[.]){2}([a-zA-Z]*)).*$";
+                Regex temp_regex = new Regex (folder_pattern);
                 MatchInfo regex_match;
                 if (temp_regex.match (fname, 0, out regex_match)) {
                     var app_name = regex_match.fetch_named ("appName");

--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -484,11 +484,11 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
             string fname = uri.split ("file://")[1];
 
             /**
-            * If a MPRIS source is Google Chrome, we can see strange file uri "file:///tmp/.com.google.Chrome.{Hash}",
-            * being stored in runtime directory, and we should handle it properly to display albumArt.
+            * For some MPRIS sources, we can see strange file uri like "file:///tmp/.com.google.Chrome.{Hash}",
+            * files being stored in users runtime directory, and we should handle it properly to display albumArt.
             */
-            if (fname.has_prefix ("/tmp/.com.google.Chrome")) {
-                fname = GLib.Environment.get_user_runtime_dir () + "/.flatpak/com.google.Chrome" + fname;
+            if (! FileUtils.test (fname, FileTest.EXISTS)) {
+                fname = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_user_runtime_dir (), ".flatpak", "com.google.Chrome", fname);
             }
 
             try {


### PR DESCRIPTION
Added new handle for albumArt from MPRIS metadata provided by Chromium based browser in a PlayerRow.

Before:
![Снимок экрана от 2024-10-04 13 36 27](https://github.com/user-attachments/assets/ca9013c8-f181-473d-9406-93e5ea4c487d)

After:
![Снимок экрана от 2024-10-10 10 13 01](https://github.com/user-attachments/assets/4793cf90-d0b9-4bbc-8db8-9b1500755a5d)

Fixes #279 