### PR TITLE
Scale: use Gtk.Adjustment

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -23,6 +23,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
     private DisplayWidget display_widget;
     private Gtk.Box main_box;
+    private Gtk.Adjustment volume_adjustment;
+    private Gtk.Adjustment mic_adjustment;
     private Widgets.PlayerList mpris;
     private Widgets.Scale volume_scale;
     private Widgets.Scale mic_scale;
@@ -131,8 +133,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
         display_widget.volume_scroll_event.connect_after (on_volume_icon_scroll_event);
         display_widget.mic_scroll_event.connect_after (on_mic_icon_scroll_event);
 
-        var volume_adjustment = new Gtk.Adjustment (0, 0, max_volume, 0.01, 0, 0);
-        var mic_adjustment = new Gtk.Adjustment (0, 0, 1, 0.01, 0, 0);
+        volume_adjustment = new Gtk.Adjustment (0, 0, max_volume, 0.01, 0, 0);
+        mic_adjustment = new Gtk.Adjustment (0, 0, 1, 0.01, 0, 0);
 
         volume_scale = new Widgets.Scale ("audio-volume-high-symbolic", volume_adjustment);
 
@@ -282,8 +284,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
     private void on_volume_change () {
         double volume = volume_control.volume.volume / max_volume;
-        if (volume != volume_scale.scale_widget.get_value ()) {
-            volume_scale.scale_widget.set_value (volume);
+        if (volume != volume_adjustment.get_value ()) {
+            volume_adjustment.set_value (volume);
             display_widget.icon_name = get_volume_icon (volume);
         }
     }
@@ -291,8 +293,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
     private void on_mic_volume_change () {
         var volume = volume_control.mic_volume;
 
-        if (volume != mic_scale.scale_widget.get_value ()) {
-            mic_scale.scale_widget.set_value (volume);
+        if (volume != mic_adjustment.get_value ()) {
+            mic_adjustment.set_value (volume);
         }
     }
 
@@ -416,8 +418,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
             mpris = new Widgets.PlayerList ();
 
             volume_scale.active = !volume_control.mute;
-            volume_scale.scale_widget.set_value (volume_control.volume.volume);
-            volume_scale.icon = get_volume_icon (volume_scale.scale_widget.get_value ());
+            volume_adjustment.set_value (volume_control.volume.volume);
+            volume_scale.icon = get_volume_icon (volume_adjustment.get_value ());
 
             set_max_volume ();
 
@@ -449,8 +451,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
             mic_scale.notify["active"].connect (on_mic_switch_change);
 
-            mic_scale.scale_widget.value_changed.connect (() => {
-                volume_control.mic_volume = mic_scale.scale_widget.get_value ();
+            mic_adjustment.value_changed.connect (() => {
+                volume_control.mic_volume = mic_adjustment.get_value ();
             });
 
             mic_scale.scale_widget.button_release_event.connect (() => {
@@ -497,14 +499,14 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
             volume_scale.notify["active"].connect (on_volume_switch_change);
 
-            volume_scale.scale_widget.value_changed.connect (() => {
-                var val = volume_scale.scale_widget.get_value () * max_volume;
+            volume_adjustment.value_changed.connect (() => {
+                var val = volume_adjustment.get_value () * max_volume;
                 var vol = new Services.VolumeControl.Volume () {
                     volume = val.clamp (0.0, max_volume),
                     reason = Services.VolumeControl.VolumeReasons.USER_KEYPRESS
                 };
                 volume_control.volume = vol;
-                volume_scale.icon = get_volume_icon (volume_scale.scale_widget.get_value ());
+                volume_scale.icon = get_volume_icon (volume_adjustment.get_value ());
             });
         }
 
@@ -679,7 +681,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
                     icon = "audio-input-microphone-symbolic";
                 }
             } else {
-                icon = get_volume_icon (volume_scale.scale_widget.get_value ());
+                icon = get_volume_icon (volume_adjustment.get_value ());
             }
 
             notification.update ("indicator-sound", "", icon);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -131,9 +131,12 @@ public class Sound.Indicator : Wingpanel.Indicator {
         display_widget.volume_scroll_event.connect_after (on_volume_icon_scroll_event);
         display_widget.mic_scroll_event.connect_after (on_mic_icon_scroll_event);
 
-        volume_scale = new Widgets.Scale ("audio-volume-high-symbolic", true, 0.0, max_volume, 0.01);
+        var volume_adjustment = new Gtk.Adjustment (0, 0, max_volume, 0.01, 0, 0);
+        var mic_adjustment = new Gtk.Adjustment (0, 0, 1, 0.01, 0, 0);
 
-        mic_scale = new Widgets.Scale ("indicator-microphone-symbolic", true, 0.0, 1.0, 0.01);
+        volume_scale = new Widgets.Scale ("audio-volume-high-symbolic", volume_adjustment);
+
+        mic_scale = new Widgets.Scale ("indicator-microphone-symbolic", mic_adjustment);
 
         ca_context = CanberraGtk.context_get ();
         ca_context.change_props (Canberra.PROP_APPLICATION_NAME, "indicator-sound",

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -16,10 +16,10 @@
 */
 
 public class Sound.Widgets.Scale : Gtk.EventBox {
-    public bool active { get; construct set; default = true; }
     public Gtk.Adjustment adjustment { get; construct; }
     public string icon { get; construct set; }
 
+    public bool active { get; set; default = true; }
     public Gtk.Scale scale_widget { get; private set; }
 
     public Scale (string icon, Gtk.Adjustment adjustment) {

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -16,20 +16,16 @@
 */
 
 public class Sound.Widgets.Scale : Gtk.EventBox {
-    public string icon { get; set; }
-    public bool active { get; construct set; }
-    public double max { get; construct; }
-    public double min { get; construct; }
-    public double step { get; construct; }
+    public bool active { get; construct set; default = true; }
+    public Gtk.Adjustment adjustment { get; construct; }
+    public string icon { get; construct set; }
+
     public Gtk.Scale scale_widget { get; private set; }
 
-    public Scale (string icon, bool active = false, double min, double max, double step) {
+    public Scale (string icon, Gtk.Adjustment adjustment) {
         Object (
-            active: active,
             icon: icon,
-            max: max,
-            min: min,
-            step: step
+            adjustment: adjustment
         );
     }
 
@@ -43,7 +39,7 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
         var toggle = new Gtk.ToggleButton ();
         toggle.image = image;
 
-        scale_widget = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, min, max, step) {
+        scale_widget = new Gtk.Scale (HORIZONTAL, adjustment) {
             draw_value = false,
             hexpand = true,
             width_request = 175


### PR DESCRIPTION
Use a Gtk.Adjustment to greatly simplify construction properties and prevent the indicator from reaching into the scale's internal widgets a bunch