### PR TITLE
PlayerRow: remove eventbutton from raise_player

### DIFF
--- a/src/Widgets/PlayerRow.vala
+++ b/src/Widgets/PlayerRow.vala
@@ -399,7 +399,7 @@ public class Sound.Widgets.PlayerRow : Gtk.Box {
         });
     }
 
-    private bool raise_player (Gdk.EventButton event) {
+    private bool raise_player () {
         try {
             close ();
             if (client != null && client.player.can_raise) {


### PR DESCRIPTION
Gdk.EventButton doesn't exist in GTK4. We don't use it here anyways