### PR TITLE
DisplayWidget: GTK4 Prep

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -114,17 +114,8 @@ public class Sound.Indicator : Wingpanel.Indicator {
 
         var locale = Intl.setlocale (LocaleCategory.MESSAGES, null);
 
-        display_widget.volume_press_event.connect ((e) => {
-            if (e.button == Gdk.BUTTON_MIDDLE) {
-                volume_control.toggle_mute ();
-            }
-        });
-
-        display_widget.mic_press_event.connect ((e) => {
-            if (e.button == Gdk.BUTTON_MIDDLE) {
-                volume_control.toggle_mic_mute ();
-            }
-        });
+        display_widget.volume_press_event.connect (volume_control.toggle_mute);
+        display_widget.mic_press_event.connect (volume_control.toggle_mic_mute);
 
         display_widget.icon_name = get_volume_icon (volume_control.volume.volume);
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -37,6 +37,7 @@ public class Sound.DisplayWidget : Gtk.Box {
         var volume_event_box = new Gtk.EventBox () {
             child = volume_icon
         };
+        volume_event_box.events = SCROLL_MASK | SMOOTH_SCROLL_MASK | BUTTON_PRESS_MASK | BUTTON_RELEASE_MASK;
 
         var mic_icon = new Gtk.Spinner () {
             margin_end = 18
@@ -46,6 +47,7 @@ public class Sound.DisplayWidget : Gtk.Box {
         var mic_event_box = new Gtk.EventBox () {
             child = mic_icon
         };
+        mic_event_box.events = SCROLL_MASK | SMOOTH_SCROLL_MASK | BUTTON_PRESS_MASK | BUTTON_RELEASE_MASK;
 
         var mic_revealer = new Gtk.Revealer () {
             child = mic_event_box,
@@ -59,14 +61,13 @@ public class Sound.DisplayWidget : Gtk.Box {
         /* SMOOTH_SCROLL_MASK has no effect on this widget for reasons that are not
          * entirely clear. Only normal scroll events are received even if the SMOOTH_SCROLL_MASK
          * is set. */
-        scroll_event.connect ((e) => {
-            /* Determine whether scrolling on mic icon or not */
-            if (show_mic && e.x < mic_icon.get_allocated_width () + mic_icon.margin_end) {
-                mic_scroll_event (e);
-            } else {
-                volume_scroll_event (e);
-            }
+        mic_event_box.scroll_event.connect ((e) => {
+            mic_scroll_event (e);
+            return Gdk.EVENT_STOP;
+        });
 
+        volume_event_box.scroll_event.connect ((e) => {
+            volume_scroll_event (e);
             return Gdk.EVENT_STOP;
         });
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -26,26 +26,35 @@ public class Sound.DisplayWidget : Gtk.Box {
     public signal void volume_scroll_event (Gdk.EventScroll e);
     public signal void mic_scroll_event (Gdk.EventScroll e);
 
+    private Gtk.GestureMultiPress mic_gesture_click;
+    private Gtk.GestureMultiPress volume_gesture_click;
+
     construct {
         var volume_icon = new Gtk.Image () {
             pixel_size = 24
         };
 
+        var volume_event_box = new Gtk.EventBox () {
+            child = volume_icon
+        };
+
         var mic_icon = new Gtk.Spinner () {
             margin_end = 18
         };
+        mic_icon.get_style_context ().add_class ("mic-icon");
 
-        var mic_style_context = mic_icon.get_style_context ();
-        mic_style_context.add_class ("mic-icon");
+        var mic_event_box = new Gtk.EventBox () {
+            child = mic_icon
+        };
 
         var mic_revealer = new Gtk.Revealer () {
-            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
+            child = mic_event_box,
+            transition_type = SLIDE_LEFT
         };
-        mic_revealer.add (mic_icon);
 
         valign = Gtk.Align.CENTER;
         add (mic_revealer);
-        add (volume_icon);
+        add (volume_event_box);
 
         /* SMOOTH_SCROLL_MASK has no effect on this widget for reasons that are not
          * entirely clear. Only normal scroll events are received even if the SMOOTH_SCROLL_MASK
@@ -61,19 +70,22 @@ public class Sound.DisplayWidget : Gtk.Box {
             return Gdk.EVENT_STOP;
         });
 
-        button_press_event.connect ((e) => {
-            if (e.button != Gdk.BUTTON_MIDDLE) {
-                return Gdk.EVENT_PROPAGATE;
-            }
+        mic_gesture_click = new Gtk.GestureMultiPress (mic_event_box) {
+            button = Gdk.BUTTON_MIDDLE
+        };
+        mic_gesture_click.pressed.connect (() => {
+            mic_press_event ();
+            mic_gesture_click.set_state (CLAIMED);
+            mic_gesture_click.reset ();
+        });
 
-            /* Determine whether scrolling on mic icon or not */
-            if (show_mic && e.x < 24 + mic_icon.margin_end) {
-                mic_press_event ();
-            } else {
-                volume_press_event ();
-            }
-
-            return Gdk.EVENT_PROPAGATE;
+        volume_gesture_click = new Gtk.GestureMultiPress (volume_event_box) {
+            button = Gdk.BUTTON_MIDDLE
+        };
+        volume_gesture_click.pressed.connect (() => {
+            volume_press_event ();
+            volume_gesture_click.set_state (CLAIMED);
+            volume_gesture_click.reset ();
         });
 
         bind_property (
@@ -91,9 +103,9 @@ public class Sound.DisplayWidget : Gtk.Box {
 
         notify["mic-muted"].connect (() => {
             if (mic_muted) {
-                mic_style_context.add_class ("disabled");
+                mic_icon.get_style_context ().add_class ("disabled");
             } else {
-                mic_style_context.remove_class ("disabled");
+                mic_icon.get_style_context ().remove_class ("disabled");
             }
         });
     }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -15,16 +15,16 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-public class DisplayWidget : Gtk.Box {
+public class Sound.DisplayWidget : Gtk.Box {
+    public signal void volume_press_event ();
+    public signal void mic_press_event ();
+
     public bool show_mic { get; set; }
     public bool mic_muted { get; set; }
     public string icon_name { get; set; }
 
     public signal void volume_scroll_event (Gdk.EventScroll e);
     public signal void mic_scroll_event (Gdk.EventScroll e);
-
-    public signal void volume_press_event (Gdk.EventButton e);
-    public signal void mic_press_event (Gdk.EventButton e);
 
     construct {
         var volume_icon = new Gtk.Image () {
@@ -62,11 +62,15 @@ public class DisplayWidget : Gtk.Box {
         });
 
         button_press_event.connect ((e) => {
+            if (e.button != Gdk.BUTTON_MIDDLE) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+
             /* Determine whether scrolling on mic icon or not */
             if (show_mic && e.x < 24 + mic_icon.margin_end) {
-                mic_press_event (e);
+                mic_press_event ();
             } else {
-                volume_press_event (e);
+                volume_press_event ();
             }
 
             return Gdk.EVENT_PROPAGATE;


### PR DESCRIPTION
* Add event box to get rid of hacky event position stuff. We can drop EventBox in GTK4
* Use Gtk.Gesture to handle middle click events
* Don't cache style context. Getting style context is deprecated