### PR TITLE
Scale: send a signal when slider dropped

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -446,11 +446,6 @@ public class Sound.Indicator : Wingpanel.Indicator {
                 volume_control.mic_volume = mic_adjustment.get_value ();
             });
 
-            mic_scale.scale_widget.button_release_event.connect (() => {
-                notify_change (true);
-                return false;
-            });
-
             mic_scale.scroll_event.connect_after ((e) => {
                 double dir = 0.0;
                 if (handle_scroll_event (e, out dir)) {
@@ -474,10 +469,7 @@ public class Sound.Indicator : Wingpanel.Indicator {
                 }
             });
 
-            volume_scale.scale_widget.button_release_event.connect ((e) => {
-                notify_change (false);
-                return false;
-            });
+            volume_scale.slider_dropped.connect (play_volume_change_sound);
 
             volume_scale.scroll_event.connect_after ((e) => {
                 double dir = 0.0;
@@ -643,16 +635,20 @@ public class Sound.Indicator : Wingpanel.Indicator {
             /* If open or no notification shown, just play sound */
             /* TODO: Should this be suppressed if mic is on? */
             if (!notification_showing) {
-                Canberra.Proplist props;
-                Canberra.Proplist.create (out props);
-                props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "volatile");
-                props.sets (Canberra.PROP_EVENT_ID, "audio-volume-change");
-                ca_context.play_full (0, props);
+                play_volume_change_sound ();
             }
 
             notify_timeout_id = 0;
             return false;
         });
+    }
+
+    private void play_volume_change_sound () {
+        Canberra.Proplist props;
+        Canberra.Proplist.create (out props);
+        props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "volatile");
+        props.sets (Canberra.PROP_EVENT_ID, "audio-volume-change");
+        ca_context.play_full (0, props);
     }
 
     /* This also plays a sound. TODO Is there a way of suppressing this if mic is on? */

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -16,6 +16,8 @@
 */
 
 public class Sound.Widgets.Scale : Gtk.EventBox {
+    public signal void slider_dropped ();
+
     public Gtk.Adjustment adjustment { get; construct; }
     public string icon { get; construct set; }
 
@@ -58,6 +60,11 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
         add (box);
         add_events (Gdk.EventMask.SMOOTH_SCROLL_MASK);
         above_child = false;
+
+        scale_widget.button_release_event.connect (() => {
+            slider_dropped ();
+            return Gdk.EVENT_PROPAGATE;
+        });
 
         scale_widget.scroll_event.connect ((e) => {
             /* Re-emit the signal on the eventbox instead of using native handler */

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -22,7 +22,6 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
     public string icon { get; construct set; }
 
     public bool active { get; set; default = true; }
-    public Gtk.Scale scale_widget { get; private set; }
 
     public Scale (string icon, Gtk.Adjustment adjustment) {
         Object (
@@ -41,7 +40,7 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
         var toggle = new Gtk.ToggleButton ();
         toggle.image = image;
 
-        scale_widget = new Gtk.Scale (HORIZONTAL, adjustment) {
+        var scale_widget = new Gtk.Scale (HORIZONTAL, adjustment) {
             draw_value = false,
             hexpand = true,
             width_request = 175


### PR DESCRIPTION
* Don't send volume change feedback when we drop the mic scale. We don't send notifications when the indicator is open and there's no reason to play a sound when the mic sensitivity changes
* When the volume slider is dropped, bypass all the complicated logic and just play the sound. We know the indicator has to be open, we know we're the volume slider, just play the sound.
* Don't expose the scale widget, send a signal. I think in GTK4 we might have to do something with observing the drag controller, I'm not sure, but that should all happen internally here and we keep it simple for the indicator who just needs to  know we dropped the slider