### PR TITLE
Scale: don't set an icon on construct

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -127,9 +127,9 @@ public class Sound.Indicator : Wingpanel.Indicator {
         volume_adjustment = new Gtk.Adjustment (0, 0, max_volume, 0.01, 0, 0);
         mic_adjustment = new Gtk.Adjustment (0, 0, 1, 0.01, 0, 0);
 
-        volume_scale = new Widgets.Scale ("audio-volume-high-symbolic", volume_adjustment);
+        volume_scale = new Widgets.Scale (volume_adjustment);
 
-        mic_scale = new Widgets.Scale ("indicator-microphone-symbolic", mic_adjustment);
+        mic_scale = new Widgets.Scale (mic_adjustment);
 
         ca_context = CanberraGtk.context_get ();
         ca_context.change_props (Canberra.PROP_APPLICATION_NAME, "indicator-sound",

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -17,16 +17,13 @@
 
 public class Sound.Widgets.Scale : Gtk.EventBox {
     public Gtk.Adjustment adjustment { get; construct; }
-    public string icon { get; construct set; }
+    public string icon { get; set; }
 
     public bool active { get; set; default = true; }
     public Gtk.Scale scale_widget { get; private set; }
 
-    public Scale (string icon, Gtk.Adjustment adjustment) {
-        Object (
-            icon: icon,
-            adjustment: adjustment
-        );
+    public Scale (Gtk.Adjustment adjustment) {
+        Object (adjustment: adjustment);
     }
 
     class construct {
@@ -34,7 +31,7 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
     }
 
     construct {
-        var image = new Gtk.Image.from_icon_name (icon, BUTTON);
+        var image = new Gtk.Image ();
 
         var toggle = new Gtk.ToggleButton ();
         toggle.image = image;


### PR DESCRIPTION
We change this immediate anyways, so no need to set it when we construct