### PR TITLE
Scale: GTK4 prep

### DIFF
--- a/data/indicator.css
+++ b/data/indicator.css
@@ -30,7 +30,7 @@
     100% { -gtk-icon-source: -gtk-icontheme("indicator-microphone-muted-symbolic"); }
 }
 
-menuitem .image-button,
+device-scale .image-button,
 player-row .image-button {
     background: alpha(@text_color, 0.1);
     border: none;
@@ -39,18 +39,18 @@ player-row .image-button {
     min-width: 2.1666rem; /* 26px */
 }
 
-menuitem .image-button.toggle,
+device-scale .image-button.toggle,
 player-row .image-button.toggle {
     border-radius: 1em;
 }
 
-menuitem .image-button:checked,
+device-scale .image-button:checked,
 player-row .image-button:checked {
     background: @selected_bg_color;
     color: @selected_fg_color;
 }
 
-menuitem .image-button:disabled,
+device-scale .image-button:disabled,
 player-row .image-button:disabled {
     background: @insensitive_bg_color;
 }

--- a/src/Widgets/Scale.vala
+++ b/src/Widgets/Scale.vala
@@ -23,12 +23,14 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
 
     public bool active { get; set; default = true; }
 
+    private Gtk.GestureMultiPress gesture_click;
+
     public Scale (Gtk.Adjustment adjustment) {
         Object (adjustment: adjustment);
     }
 
     class construct {
-        set_css_name (Gtk.STYLE_CLASS_MENUITEM);
+        set_css_name ("device-scale");
     }
 
     construct {
@@ -53,13 +55,13 @@ public class Sound.Widgets.Scale : Gtk.EventBox {
         box.add (toggle);
         box.add (scale_widget);
 
-        add (box);
+        child = box;
         add_events (Gdk.EventMask.SMOOTH_SCROLL_MASK);
         above_child = false;
 
-        scale_widget.button_release_event.connect (() => {
+        gesture_click = new Gtk.GestureMultiPress (scale_widget);
+        gesture_click.released.connect (() => {
             slider_dropped ();
-            return Gdk.EVENT_PROPAGATE;
         });
 
         scale_widget.scroll_event.connect ((e) => {


### PR DESCRIPTION
* No `menuitem` constant in GTK4, replace with our own css name
* Use gesture instead of `button_release_event`
* child property