### PR TITLE
Fix the microphone symbol appearing on playback

### DIFF
--- a/src/Services/Volume-control.vala
+++ b/src/Services/Volume-control.vala
@@ -233,7 +233,9 @@ public class Sound.Services.VolumeControlPulse : VolumeControl {
             this.notify_property ("micMute");
         }
 
-        var listening = (i.state == PulseAudio.SourceState.RUNNING);
+        // If there is no input device, SourceInfo will correspond to the playback device, which we want to ignore.
+        // In that scenario, monitor_of_sink != INVALID_INDEX and monitor_of_sink_name is set.
+        var listening = i.state == PulseAudio.SourceState.RUNNING && i.monitor_of_sink == PulseAudio.INVALID_INDEX;
         if (_is_listening != listening) {
             _is_listening = listening;
             this.notify_property ("is-listening");


### PR DESCRIPTION
I do not think there is an open issue for this.

Without this fix, the mic symbol appears in the panel when sound is played while there is no input device connected. The volume slider and mute button also appear inside the volume widget, with an empty input device list:
<img width="321" height="397" alt="image" src="https://github.com/user-attachments/assets/d1489268-cb00-4b9d-b1d7-00650d60e50c" />

This is due to the playback device being passed as an input (`SourceInfo`). The modifications just ignore output devices in the input detection.
To be honest, I am not sure that this is normal behavior in the first place. This could mean this PR is more of a workaround.
For example here are the respective device name and description I got as an input when I investigated this : `alsa_output.pci-0000_00_1f.3.analog-stereo.monitor` `Monitor of Built-in Audio Analog Stereo`

- ~Also reduce margin between microphone symbol and speaker one~ addressed in another PR