### PR TITLE
Reduce margin between microphone and speaker by using composited-indicator class

### DIFF
--- a/data/indicator.css
+++ b/data/indicator.css
@@ -8,6 +8,7 @@
     min-width: 24px;
     opacity: 1;
     transition: none;
+    padding-left: 0;
     -gtk-icon-source: -gtk-icontheme("indicator-microphone-symbolic");
 }
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -39,10 +39,9 @@ public class Sound.DisplayWidget : Gtk.Box {
         };
         volume_event_box.events = SCROLL_MASK | SMOOTH_SCROLL_MASK | BUTTON_PRESS_MASK | BUTTON_RELEASE_MASK;
 
-        var mic_icon = new Gtk.Spinner () {
-            margin_end = 18
-        };
+        var mic_icon = new Gtk.Spinner ();
         mic_icon.get_style_context ().add_class ("mic-icon");
+        mic_icon.get_style_context ().add_class ("composited-indicator");
 
         var mic_event_box = new Gtk.EventBox () {
             child = mic_icon


### PR DESCRIPTION
- Addresses #46

Before, 18px margin: 
<img width="297" height="30" alt="image" src="https://github.com/user-attachments/assets/577d07a8-6011-47db-93b8-db9e84926891" />

After, composited-indicator padding:
<img width="315" height="30" alt="mic-indicator_with-composited-indicator" src="https://github.com/user-attachments/assets/137e471e-164f-4b31-aa6e-6c42c355d97b" />

Test with no margin or padding (which I prefer personally since it better "links" the icons opening the same widget, but this is up for debate):
<img width="283" height="37" alt="mic-icon_no-composited-indicator" src="https://github.com/user-attachments/assets/fd11637c-6a46-4598-aa71-a4ea8993305c" />