### PR TITLE
Fix selection failures

### DIFF
--- a/src/Services/PulseAudioManager.vala
+++ b/src/Services/PulseAudioManager.vala
@@ -80,11 +80,13 @@ public class Sound.PulseAudioManager : GLib.Object {
         // for example to switch between onboard speakers to hdmi
         // the profile has to be switched from analog stereo to digital stereo.
         // Attempt to find profiles that support both selected input and output
-        var other_device = default_input;
-        var card_name = "card-sink-name";
+        var other_device = default_output;
+        var direction_name = "source-name";
+        var card_direction_name = "card-source-name";
         if (device.direction == OUTPUT) {
-            other_device = default_output;
-            card_name = "card-source-name";
+            other_device = default_input;
+            direction_name = "sink-name";
+            card_direction_name = "card-sink-name";
         }
 
         var profile_name = device.get_matching_profile (other_device);
@@ -99,7 +101,7 @@ public class Sound.PulseAudioManager : GLib.Object {
             yield set_card_profile_by_index (device.card_index, profile_name);
             // wait for new card sink to appear
             debug ("wait for card sink / source");
-            yield wait_for_update (device, card_name);
+            yield wait_for_update (device, card_direction_name);
         }
 
         // #2 Set sink / source port
@@ -119,7 +121,7 @@ public class Sound.PulseAudioManager : GLib.Object {
         if (device.direction == OUTPUT && device.sink_name == null ||
             device.direction == INPUT && device.source_name == null) {
             debug ("wait for sink / source");
-            yield wait_for_update (device, card_name);
+            yield wait_for_update (device, direction_name);
         }
 
         // #4 Set sink / source

--- a/src/Services/PulseAudioManager.vala
+++ b/src/Services/PulseAudioManager.vala
@@ -463,8 +463,11 @@ public class Sound.PulseAudioManager : GLib.Object {
                 device.card_sink_name = sink.name;
                 debug ("\t\t\tdevice.card_sink_name: %s", device.card_sink_name);
 
-                if (sink.active_port != null && device.port_name == sink.active_port.name) {
+                if (sink.active_port != null) {
                     device.card_sink_port_name = sink.active_port.name;
+                }
+
+                if (sink.active_port != null && device.port_name == sink.active_port.name) {
                     device.sink_name = sink.name;
                     debug ("\t\t\tdevice.sink_name: %s", device.card_sink_name);
                     device.sink_index = (int)sink.index;


### PR DESCRIPTION
The current behaviour of the output list is very spotty, especially for devices with multiples inputs/outputs.
This PR addresses this, with two fixes. It resolves #223.

With both fixes, output selection is now working correctly even when the device has multiple outputs or some input. The behaviour is now the same as in sound settings.

#### First fix: Device card_sink_port_name was not set when it could have.

Not setting card_sink_port_name could induce failure of `PulseAudioManager.set_default_device ()`.
Hence action #2 "Set sink / source port" was not triggered.
Then action #3 "Wait for sink / source" failed and the default device was not set.

This would result in a selection of an of the output of a device with multiple ones to not have any effect (only one is working, without a way to know which one).

#### Second fix: Input and Output were reversed when checking card profiles

Selection of an output of devices with some input may not have any effect because of this.
It was introduced by #293.