### PR TITLE
Reduce zone not reacting to clicks for output selection

### DIFF
--- a/data/indicator.css
+++ b/data/indicator.css
@@ -55,3 +55,15 @@ device-scale .image-button:disabled,
 player-row .image-button:disabled {
     background: @insensitive_bg_color;
 }
+
+/* Default menuitem padding is 6px.
+   Reduce it on the item and increase it on the radio button to ease toggling.
+   Leave 1 pixel padding to not select when the mouse is "on the border" of items to avoid miss-clicks. */
+menuitem.radio-list {
+    padding-top: 1px;
+    padding-bottom: 1px;
+}
+menuitem.radio-list radiobutton {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}

--- a/src/Widgets/DeviceItem.vala
+++ b/src/Widgets/DeviceItem.vala
@@ -23,6 +23,11 @@ public class Sound.Widgets.DeviceItem : Gtk.ListBoxRow {
     }
 
     construct {
+        // Add "radio-list" CSS class
+        Gtk.StyleContext context;
+        context = get_style_context ();
+        context.add_class ("radio-list");
+
         var label = new Gtk.Label (device.display_name) {
             halign = START,
             hexpand = true,


### PR DESCRIPTION
Many times, I think I am clicking on the output I want to select, when in fact I am clicking on its padding. So it does not select it (and the selection zone is not visible), even if the output line is highlighted when hovered.
This evolution reduces the padding ; maybe not in the most elegant fashion, so suggestions are welcome.

- Previously was 12px tall between two outputs (6px each, default value)
- Now is 2px tall. Zone not removed entirely to avoid misclicks when on the border of two items